### PR TITLE
Add support for Batch API Calls

### DIFF
--- a/lib/eventbrite/eventbrite_v3.js
+++ b/lib/eventbrite/eventbrite_v3.js
@@ -49,7 +49,12 @@ eventbriteAPI_v3.prototype.execute = function (verb, resource, method, available
     "User-Agent": this.userAgent
   };
 
-  var uri = this.httpUri + '/' + this.version + '/' + resource + '/' + method;
+  var uri = this.httpUri + '/' + this.version + '/' + resource + '/';
+
+  // Fix to only add method if it is set, otherwise "null" is added
+  if(method){
+    uri = uri + method + '/';
+  }
 
   var finalParams = {};
   var currentParam;
@@ -77,6 +82,10 @@ eventbriteAPI_v3.prototype.execute = function (verb, resource, method, available
   // Either add params to qs or body based on method
   if (verb === 'GET') {
     requestObject.qs = finalParams;
+  } else if (resource === 'batch') {
+    // application/json does not work for this endpoint, let's fix it
+    requestObject.headers["Content-Type"] = 'application/x-www-form-urlencoded';
+    requestObject.body = 'batch=' + encodeURIComponent(JSON.stringify(finalParams.batch));
   } else if (verb === 'POST') {
     requestObject.body = JSON.stringify(finalParams);
   }
@@ -91,11 +100,34 @@ eventbriteAPI_v3.prototype.execute = function (verb, resource, method, available
       return callback(err);
     } else {
 
-      try {
-        parsedResponse = JSON.parse(body);
-      } catch (error) {
-        if (this.DEBUG)console.log("error", error);
-        return callback(new Error('Error parsing JSON answer from eventbrite API.'));
+      if(resource === 'batch'){
+        // if there was a batch error, body will be normal API JSON string, it should always be an objects
+        if(typeof body === 'string'){
+          try {
+            parsedResponse = JSON.parse(body);
+
+            // see if we got a specific error
+            if(parsedResponse.error){
+              if (this.DEBUG)console.log("error", parsedResponse.error, parsedResponse.error_description);
+              return callback(new Error(parsedResponse.error + '' + parsedResponse.error_description));
+            }
+
+            // No specific error given
+            return callback(new Error('Error parsing JSON answer from eventbrite API.'));
+          } catch (error) {
+            if (this.DEBUG)console.log("error", error);
+            return callback(new Error('Error parsing JSON answer from eventbrite API.'));
+          }
+        } else {
+          parsedResponse = body;
+        }
+      } else {
+        try {
+          parsedResponse = JSON.parse(body);
+        } catch (error) {
+          if (this.DEBUG)console.log("error", error);
+          return callback(new Error('Error parsing JSON answer from eventbrite API.'));
+        }
       }
 
       if (parsedResponse.error) {
@@ -258,7 +290,7 @@ eventbriteAPI_v3.prototype.event_orders = function (params, callback) {
  **/
 eventbriteAPI_v3.prototype.user_details = function (params, callback) {
   var user_id = params.user_id || "me",
-    availableParams = [];
+      availableParams = [];
 
   var method = user_id + "/";
 
@@ -390,6 +422,18 @@ eventbriteAPI_v3.prototype.user_organizers = function (params, callback) {
   this.get('users', method, availableParams, params, callback);
 };
 
+/**
+ * To save on the added latency of doing several API requests at once
+ * especially in high-latency environments like mobile data - it’s possible to
+ * do a batched request to the API and have our servers process all of your
+ * requests at once, saving you the cost of several request round trips.
+ * @see https://www.eventbrite.com/developer/v3/reference/batching/
+ **/
+eventbriteAPI_v3.prototype.batch = function (params, callback) {
+  var availableParams = ["batch"];
+
+  this.post('batch', null, availableParams, params, callback);
+};
 
 /*****************************************************************************/
 /************************* ORDER Related Methods **************************/

--- a/lib/eventbrite/eventbrite_v3.js
+++ b/lib/eventbrite/eventbrite_v3.js
@@ -100,34 +100,15 @@ eventbriteAPI_v3.prototype.execute = function (verb, resource, method, available
       return callback(err);
     } else {
 
-      if(resource === 'batch'){
-        // if there was a batch error, body will be normal API JSON string, it should always be an objects
-        if(typeof body === 'string'){
-          try {
-            parsedResponse = JSON.parse(body);
-
-            // see if we got a specific error
-            if(parsedResponse.error){
-              if (this.DEBUG)console.log("error", parsedResponse.error, parsedResponse.error_description);
-              return callback(new Error(parsedResponse.error + '' + parsedResponse.error_description));
-            }
-
-            // No specific error given
-            return callback(new Error('Error parsing JSON answer from eventbrite API.'));
-          } catch (error) {
-            if (this.DEBUG)console.log("error", error);
-            return callback(new Error('Error parsing JSON answer from eventbrite API.'));
-          }
-        } else {
-          parsedResponse = body;
+      try {
+        parsedResponse = JSON.parse(body);
+        if(parsedResponse.error){
+          if (this.DEBUG)console.log("error", parsedResponse.error, parsedResponse.error_description);
+          return callback(new Error(parsedResponse.error + '' + parsedResponse.error_description));
         }
-      } else {
-        try {
-          parsedResponse = JSON.parse(body);
-        } catch (error) {
-          if (this.DEBUG)console.log("error", error);
-          return callback(new Error('Error parsing JSON answer from eventbrite API.'));
-        }
+      } catch (error) {
+        if (this.DEBUG)console.log("error", error);
+        return callback(new Error('Error parsing JSON answer from eventbrite API.'));
       }
 
       if (parsedResponse.error) {
@@ -290,7 +271,7 @@ eventbriteAPI_v3.prototype.event_orders = function (params, callback) {
  **/
 eventbriteAPI_v3.prototype.user_details = function (params, callback) {
   var user_id = params.user_id || "me",
-      availableParams = [];
+    availableParams = [];
 
   var method = user_id + "/";
 


### PR DESCRIPTION
Overview:
---

Add's support for Batch API Calls ( one API call sent to Eventbrite to process multiple API calls with one returned response ).

See https://www.eventbriteapi.com/v3/batch/ for details.

Weirdness:
---

The `batch` endpoint does not appear to support `application/json` encoding as the rest of the API does.  This appears to be because a batch parameter is required that contains JSON ( stringified ).  So there is a check added if the `resource` is `batch` and replaces the `Content-type` header to `application/x-www-form-urlencoded` which is what their API seemed to use.

Also, it appears the response that comes back sets `body` as an actual Object

Sample Code:
---

```js
this.client = eventbrite({
   token: config.get('eventbrite.personal_token')
});

var params = {
  "batch": [
    {
      "method": "GET",
      "relative_url": "events/search/?venue.city=Portland&venue.region=OR&venue.country=US"
    },
    {
      "method": "GET",
      "relative_url": "events/search/?venue.city=Portland&venue.region=OR&venue.country=US&page=2"
    },
    {
      "method": "GET",
      "relative_url": "events/search/?venue.city=Portland&venue.region=OR&venue.country=US&page=3"
    }
  ]
};

self.client.batch(params, function(error, data) {
  if (error) {
    // do something with error
  } else {
    // data has the combined output of all API calls in an array, one item for each API call
  }
});
```