### PR TITLE
Changed content-type to only be used on POST requests

### DIFF
--- a/lib/eventbrite/eventbrite_v3.js
+++ b/lib/eventbrite/eventbrite_v3.js
@@ -1,6 +1,6 @@
 var http = require('http'),
-  request = require('request'),
-  helpers = require('./helpers');
+	request = require('request'),
+	helpers = require('./helpers');
 
 /**
  * eventbrite API wrapper for the API version 3. This object should not be
@@ -11,18 +11,18 @@ var http = require('http'),
  */
 function eventbriteAPI_v3(options) {
 
-  if (!options) {
-    throw new Error('Something went wrong, API requires: {token: YOUR_TOKEN}');
-  } else if (!options.token) {
-    throw new Error('You have to provide a token for this to work.');
-  }
+	if (!options) {
+		throw new Error('Something went wrong, API requires: {token: YOUR_TOKEN}');
+	} else if (!options.token) {
+		throw new Error('You have to provide a token for this to work.');
+	}
 
-  this.version = 'v3';
-  this.httpUri = 'https://www.eventbriteapi.com';
-  this.token = options.token;
-  this.DEBUG = options.DEBUG || false;
-  this.contentType = options.contentType || 'application/json';
-  this.userAgent = options.userAgent || 'node-eventbrite/' + this.version;
+	this.version = 'v3';
+	this.httpUri = 'https://www.eventbriteapi.com';
+	this.token = options.token;
+	this.DEBUG = options.DEBUG || false;
+	this.contentType = options.contentType || 'application/json';
+	this.userAgent = options.userAgent || 'node-eventbrite/' + this.version;
 }
 
 module.exports = eventbriteAPI_v3;
@@ -39,83 +39,92 @@ module.exports = eventbriteAPI_v3;
  * @param givenParams Parameters to call the eventbrite API with
  * @param callback Callback function to call on success
  */
-eventbriteAPI_v3.prototype.execute = function (verb, resource, method, availableParams, givenParams, callback) {
-  if (!verb) {
-    verb = "GET";
-  }
-  var headers = {
-    "Content-Type": this.contentType,
-    "Authorization": 'Bearer ' + this.token,
-    "User-Agent": this.userAgent
-  };
+eventbriteAPI_v3.prototype.execute = function(verb, resource, method,
+	availableParams, givenParams, callback) {
+	if (!verb) {
+		verb = "GET";
+	}
 
-  var uri = this.httpUri + '/' + this.version + '/' + resource + '/' + method;
+	var headers = {
+		"Authorization": 'Bearer ' + this.token,
+		"User-Agent": this.userAgent
+	};
 
-  var finalParams = {};
-  var currentParam;
+	//only set content type on POST requests
+	if (verb != "GET") {
+		headers["Content-Type"] = this.contentType;
+	}
 
-  for (var i = 0; i < availableParams.length; i++) {
-    currentParam = availableParams[i];
-    if (typeof givenParams[currentParam] !== 'undefined')
-      finalParams[currentParam] = givenParams[currentParam];
-  }
+	var uri = this.httpUri + '/' + this.version + '/' + resource + '/' + method;
 
-  if (this.DEBUG) {
-    console.log("uri", uri);
-    console.log("verb", verb);
-    console.log("headers", headers);
-    console.log("finalParams", finalParams);
-  }
+	var finalParams = {};
+	var currentParam;
 
-  // Build our request object
-  var requestObject = {
-    uri: uri,
-    method: verb,
-    headers: headers
-  };
+	for (var i = 0; i < availableParams.length; i++) {
+		currentParam = availableParams[i];
+		if (typeof givenParams[currentParam] !== 'undefined')
+			finalParams[currentParam] = givenParams[currentParam];
+	}
 
-  // Either add params to qs or body based on method
-  if (verb === 'GET') {
-    requestObject.qs = finalParams;
-  } else if (verb === 'POST') {
-    requestObject.body = JSON.stringify(finalParams);
-  }
+	if (this.DEBUG) {
+		console.log("uri", uri);
+		console.log("verb", verb);
+		console.log("headers", headers);
+		console.log("finalParams", finalParams);
+	}
 
-  request(requestObject, function (error, response, body) {
-    var parsedResponse;
-    if (error) {
-      if (this.DEBUG)console.log("error", error);
-      var err = new Error('Unable to connect to the eventbrite API endpoint.');
-      err.error_message = error;
-      err.code = "REQUEST_ERROR";
-      return callback(err);
-    } else {
+	// Build our request object
+	var requestObject = {
+		uri: uri,
+		method: verb,
+		headers: headers
+	};
 
-      try {
-        parsedResponse = JSON.parse(body);
-      } catch (error) {
-        if (this.DEBUG)console.log("error", error);
-        return callback(new Error('Error parsing JSON answer from eventbrite API.'));
-      }
+	// Either add params to qs or body based on method
+	if (verb === 'GET') {
+		requestObject.qs = finalParams;
+	} else if (verb === 'POST') {
+		requestObject.body = JSON.stringify(finalParams);
+	}
 
-      if (parsedResponse.error) {
-        if (this.DEBUG)console.log("error", parsedResponse);
-        return callback(helpers.createEventbriteError(parsedResponse));
-      }
+	request(requestObject, function(error, response, body) {
+		var parsedResponse;
+		if (error) {
+			if (this.DEBUG) console.log("error", error);
+			var err = new Error('Unable to connect to the eventbrite API endpoint.');
+			err.error_message = error;
+			err.code = "REQUEST_ERROR";
+			return callback(err);
+		} else {
 
-      return callback(null, parsedResponse);
+			try {
+				parsedResponse = JSON.parse(body);
+			} catch (error) {
+				if (this.DEBUG) console.log("error", error);
+				return callback(new Error(
+					'Error parsing JSON answer from eventbrite API.'));
+			}
 
-    }
-  });
+			if (parsedResponse.error) {
+				if (this.DEBUG) console.log("error", parsedResponse);
+				return callback(helpers.createEventbriteError(parsedResponse));
+			}
+
+			return callback(null, parsedResponse);
+
+		}
+	});
 
 };
 
-eventbriteAPI_v3.prototype.get = function (resource, method, availableParams, givenParams, callback) {
-  this.execute("GET", resource, method, availableParams, givenParams, callback)
+eventbriteAPI_v3.prototype.get = function(resource, method, availableParams,
+	givenParams, callback) {
+	this.execute("GET", resource, method, availableParams, givenParams, callback)
 };
 
-eventbriteAPI_v3.prototype.post = function (resource, method, availableParams, givenParams, callback) {
-  this.execute("POST", resource, method, availableParams, givenParams, callback)
+eventbriteAPI_v3.prototype.post = function(resource, method, availableParams,
+	givenParams, callback) {
+	this.execute("POST", resource, method, availableParams, givenParams, callback)
 };
 
 
@@ -129,36 +138,36 @@ eventbriteAPI_v3.prototype.post = function (resource, method, availableParams, g
  *
  * @see http://developer.eventbrite.com/docs/event-search/
  **/
-eventbriteAPI_v3.prototype.search = function (params, callback) {
-  var availableParams = [
-    "q", // Pass in a value for ‘q’ that is a query and will return events matching the given keyword(s).
-    "since_id", //Pass in the last ‘Event ID’ to only return events that have been created after this Event ID.
-    "sort_by", //Sort the list of events by “id”, “date”, “name”, “city”. The default is “date”.
-    "popular", //[Boolean] Pass in ‘true’ to only receive a subset of events that have already sold a minimum threshold of tickets and received a minimum amount of social engagement.
-    "location.address",  //The address of the location that you want to search around.
-    "location.latitude", //The latitude of the location that you want to search around.
-    "location.longitude", //The longitude of the location that you want to search around.
-    "location.within", //The distance that you want to search around the given location. This should be an integer followed by “mi” or “km”.
-    "venue.city", //Only return events that are located in the given city.
-    "venue.region", //Only return events that are located in the given region.
-    "venue.country", //Only return events that are located in the given country.
-    "organizer.id", //Only return events that are organized by a specific Organizer.
-    "user.id",  //Only return events that are organized by a specific User.
-    "tracking_code", //Append the given tracking_code to the event URLs that are returned.
-    "categories", //Only return events that are in a specific category — must pass in the category ID, not the name. To pass in multiple categories, list with a comma separator.
-    "formats", //Only return events that are in a specific format. To pass in multiple formats, list with a comma separator.
-    "start_date.range_start",  //Only return events with start dates after the given UTC date.
-    "start_date.range_end", //Only return events with start dates before the given UTC date.
-    "start_date.keyword", //Only return events with start dates within the given keyword date range. Valid options are “today”, “tomorrow”, “this_week”, “this_weekend”, “next_week”, and “this_month”.
-    "date_created.range_start", //Only return events with date created after the given UTC date.
-    "date_created.range_end", //Only return events with date created before the given UTC date.
-    "date_created.keyword", //Only return events with date created within the given keyword date range. Valid options are “today”, “tomorrow”, “this_week”, “this_weekend”, “next_week”, and “this_month”.
-    "date_modified.range_start", //Only return events with date_modified after the given UTC date.
-    "date_modified.range_end", //Only return events with date_modified before the given UTC date.
-    "date_modified.keyword", //Only return events with date_modified within the given keyword date range. Valid options are “today”, “tomorrow”, “this_week”, “this_weekend”, “next_week”, and “this_month”.
-  ];
+eventbriteAPI_v3.prototype.search = function(params, callback) {
+	var availableParams = [
+		"q", // Pass in a value for ‘q’ that is a query and will return events matching the given keyword(s).
+		"since_id", //Pass in the last ‘Event ID’ to only return events that have been created after this Event ID.
+		"sort_by", //Sort the list of events by “id”, “date”, “name”, “city”. The default is “date”.
+		"popular", //[Boolean] Pass in ‘true’ to only receive a subset of events that have already sold a minimum threshold of tickets and received a minimum amount of social engagement.
+		"location.address", //The address of the location that you want to search around.
+		"location.latitude", //The latitude of the location that you want to search around.
+		"location.longitude", //The longitude of the location that you want to search around.
+		"location.within", //The distance that you want to search around the given location. This should be an integer followed by “mi” or “km”.
+		"venue.city", //Only return events that are located in the given city.
+		"venue.region", //Only return events that are located in the given region.
+		"venue.country", //Only return events that are located in the given country.
+		"organizer.id", //Only return events that are organized by a specific Organizer.
+		"user.id", //Only return events that are organized by a specific User.
+		"tracking_code", //Append the given tracking_code to the event URLs that are returned.
+		"categories", //Only return events that are in a specific category — must pass in the category ID, not the name. To pass in multiple categories, list with a comma separator.
+		"formats", //Only return events that are in a specific format. To pass in multiple formats, list with a comma separator.
+		"start_date.range_start", //Only return events with start dates after the given UTC date.
+		"start_date.range_end", //Only return events with start dates before the given UTC date.
+		"start_date.keyword", //Only return events with start dates within the given keyword date range. Valid options are “today”, “tomorrow”, “this_week”, “this_weekend”, “next_week”, and “this_month”.
+		"date_created.range_start", //Only return events with date created after the given UTC date.
+		"date_created.range_end", //Only return events with date created before the given UTC date.
+		"date_created.keyword", //Only return events with date created within the given keyword date range. Valid options are “today”, “tomorrow”, “this_week”, “this_weekend”, “next_week”, and “this_month”.
+		"date_modified.range_start", //Only return events with date_modified after the given UTC date.
+		"date_modified.range_end", //Only return events with date_modified before the given UTC date.
+		"date_modified.keyword", //Only return events with date_modified within the given keyword date range. Valid options are “today”, “tomorrow”, “this_week”, “this_weekend”, “next_week”, and “this_month”.
+	];
 
-  this.get("events", "search", availableParams, params, callback);
+	this.get("events", "search", availableParams, params, callback);
 };
 
 
@@ -167,8 +176,8 @@ eventbriteAPI_v3.prototype.search = function (params, callback) {
  *
  * @see http://developer.eventbrite.com/docs/event-categories/
  **/
-eventbriteAPI_v3.prototype.categories = function (callback) {
-  this.get('categories', null, [], [], callback);
+eventbriteAPI_v3.prototype.categories = function(callback) {
+	this.get('categories', null, [], [], callback);
 };
 
 
@@ -178,18 +187,18 @@ eventbriteAPI_v3.prototype.categories = function (callback) {
  * @see http://developer.eventbrite.com/docs/event-details/
  **/
 
-eventbriteAPI_v3.prototype.event_details = function (params, callback) {
-  if (!params.event_id) {
-    return callback("This request requires an event_id", null)
-  }
+eventbriteAPI_v3.prototype.event_details = function(params, callback) {
+	if (!params.event_id) {
+		return callback("This request requires an event_id", null)
+	}
 
-  var availableParams = [
-    "status",
-    "changed_since"
-  ];
+	var availableParams = [
+		"status",
+		"changed_since"
+	];
 
-  var method = params.event_id + "/";
-  this.get('events', method, availableParams, params, callback);
+	var method = params.event_id + "/";
+	this.get('events', method, availableParams, params, callback);
 };
 
 
@@ -199,19 +208,19 @@ eventbriteAPI_v3.prototype.event_details = function (params, callback) {
  * @see http://developer.eventbrite.com/docs/event-attendees/
  **/
 
-eventbriteAPI_v3.prototype.event_attendees = function (params, callback) {
-  if (!params.event_id) {
-    return callback("This request requires an event_id", null)
-  }
+eventbriteAPI_v3.prototype.event_attendees = function(params, callback) {
+	if (!params.event_id) {
+		return callback("This request requires an event_id", null)
+	}
 
-  var availableParams = [
-    "page",
-    "status",
-    "changed_since",
-    "expand"
-  ];
-  var method = params.event_id + "/attendees/";
-  this.get('events', method, availableParams, params, callback);
+	var availableParams = [
+		"page",
+		"status",
+		"changed_since",
+		"expand"
+	];
+	var method = params.event_id + "/attendees/";
+	this.get('events', method, availableParams, params, callback);
 };
 
 
@@ -223,19 +232,19 @@ eventbriteAPI_v3.prototype.event_attendees = function (params, callback) {
  * @see http://developer.eventbrite.com/docs/event-orders/
  **/
 
-eventbriteAPI_v3.prototype.event_orders = function (params, callback) {
-  if (!params.event_id) {
-    return callback("This request requires an event_id", null)
-  }
+eventbriteAPI_v3.prototype.event_orders = function(params, callback) {
+	if (!params.event_id) {
+		return callback("This request requires an event_id", null)
+	}
 
-  var availableParams = [
-    "page",
-    "status",
-    "changed_since"
-  ];
+	var availableParams = [
+		"page",
+		"status",
+		"changed_since"
+	];
 
-  var method = params.event_id + "/orders/";
-  this.get('events', method, availableParams, params, callback);
+	var method = params.event_id + "/orders/";
+	this.get('events', method, availableParams, params, callback);
 };
 
 //[http://developer.eventbrite.com/docs/event-discounts](Event Discounts)
@@ -256,13 +265,13 @@ eventbriteAPI_v3.prototype.event_orders = function (params, callback) {
  *
  * @see http://developer.eventbrite.com/docs/user-details/
  **/
-eventbriteAPI_v3.prototype.user_details = function (params, callback) {
-  var user_id = params.user_id || "me",
-    availableParams = [];
+eventbriteAPI_v3.prototype.user_details = function(params, callback) {
+	var user_id = params.user_id || "me",
+		availableParams = [];
 
-  var method = user_id + "/";
+	var method = user_id + "/";
 
-  this.get('users', method, availableParams, params, callback);
+	this.get('users', method, availableParams, params, callback);
 };
 
 
@@ -271,8 +280,10 @@ eventbriteAPI_v3.prototype.user_details = function (params, callback) {
  *
  * @see http://developer.eventbrite.com/docs/user-details/
  **/
-eventbriteAPI_v3.prototype.me = function (callback) {
-  this.user_details({user_id: 'me'}, callback);
+eventbriteAPI_v3.prototype.me = function(callback) {
+	this.user_details({
+		user_id: 'me'
+	}, callback);
 };
 
 
@@ -281,13 +292,13 @@ eventbriteAPI_v3.prototype.me = function (callback) {
  * If you do not include a user_id, we will include one for you :)
  * @see http://developer.eventbrite.com/docs/user-orders/
  **/
-eventbriteAPI_v3.prototype.user_orders = function (params, callback) {
-  var user_id = params.user_id || "me";
+eventbriteAPI_v3.prototype.user_orders = function(params, callback) {
+	var user_id = params.user_id || "me";
 
-  var availableParams = ["page"];
+	var availableParams = ["page"];
 
-  var method = user_id + "/orders/";
-  this.get('users', method, availableParams, params, callback);
+	var method = user_id + "/orders/";
+	this.get('users', method, availableParams, params, callback);
 };
 
 
@@ -296,17 +307,17 @@ eventbriteAPI_v3.prototype.user_orders = function (params, callback) {
  * If you do not include a user_id, we will include one for you :)
  * @see http://developer.eventbrite.com/docs/user-owned-events/
  **/
-eventbriteAPI_v3.prototype.user_owned_events = function (params, callback) {
-  var user_id = params.user_id || "me";
+eventbriteAPI_v3.prototype.user_owned_events = function(params, callback) {
+	var user_id = params.user_id || "me";
 
-  var availableParams = [
-    "page",
-    "status",
-    "order_by"
-  ];
+	var availableParams = [
+		"page",
+		"status",
+		"order_by"
+	];
 
-  var method = user_id + "/owned_events/";
-  this.get('users', method, availableParams, params, callback);
+	var method = user_id + "/owned_events/";
+	this.get('users', method, availableParams, params, callback);
 };
 
 /**
@@ -315,17 +326,17 @@ eventbriteAPI_v3.prototype.user_owned_events = function (params, callback) {
  * If you do not include a user_id, we will include one for you :)
  * @see https://www.eventbrite.com/developer/v3/endpoints/users/#ebapi-get-users-id-events
  **/
-eventbriteAPI_v3.prototype.user_events = function (params, callback) {
-  var user_id = params.user_id || "me";
+eventbriteAPI_v3.prototype.user_events = function(params, callback) {
+	var user_id = params.user_id || "me";
 
-  var availableParams = [
-    "page",
-    "status",
-    "order_by"
-  ];
+	var availableParams = [
+		"page",
+		"status",
+		"order_by"
+	];
 
-  var method = user_id + "/events/";
-  this.get('users', method, availableParams, params, callback);
+	var method = user_id + "/events/";
+	this.get('users', method, availableParams, params, callback);
 };
 
 /**
@@ -333,13 +344,13 @@ eventbriteAPI_v3.prototype.user_events = function (params, callback) {
  * If you do not include a user_id, we will include one for you :)
  * @see http://developer.eventbrite.com/docs/user-owned-events-orders/
  **/
-eventbriteAPI_v3.prototype.user_owned_events_orders = function (params, callback) {
-  var user_id = params.user_id || "me";
+eventbriteAPI_v3.prototype.user_owned_events_orders = function(params, callback) {
+	var user_id = params.user_id || "me";
 
-  var availableParams = ["page"];
+	var availableParams = ["page"];
 
-  var method = user_id + "/owned_event_orders/";
-  this.get('users', method, availableParams, params, callback);
+	var method = user_id + "/owned_event_orders/";
+	this.get('users', method, availableParams, params, callback);
 };
 
 
@@ -348,16 +359,17 @@ eventbriteAPI_v3.prototype.user_owned_events_orders = function (params, callback
  * If you do not include a user_id, we will include one for you :)
  * @see http://developer.eventbrite.com/docs/user-owned-events-attendees/
  **/
-eventbriteAPI_v3.prototype.user_owned_events_attendees = function (params, callback) {
-  var user_id = params.user_id || "me";
+eventbriteAPI_v3.prototype.user_owned_events_attendees = function(params,
+	callback) {
+	var user_id = params.user_id || "me";
 
-  var availableParams = [
-    "page",
-    "expand"
-  ];
+	var availableParams = [
+		"page",
+		"expand"
+	];
 
-  var method = user_id + "/owned_event_attendees/";
-  this.get('users', method, availableParams, params, callback);
+	var method = user_id + "/owned_event_attendees/";
+	this.get('users', method, availableParams, params, callback);
 };
 
 
@@ -366,13 +378,13 @@ eventbriteAPI_v3.prototype.user_owned_events_attendees = function (params, callb
  * If you do not include a user_id, we will include one for you :)
  * @see http://developer.eventbrite.com/docs/user-venues/
  **/
-eventbriteAPI_v3.prototype.user_venues = function (params, callback) {
-  var user_id = params.user_id || "me";
+eventbriteAPI_v3.prototype.user_venues = function(params, callback) {
+	var user_id = params.user_id || "me";
 
-  var availableParams = ["page"];
+	var availableParams = ["page"];
 
-  var method = user_id + "/venues/";
-  this.get('users', method, availableParams, params, callback);
+	var method = user_id + "/venues/";
+	this.get('users', method, availableParams, params, callback);
 };
 
 
@@ -381,13 +393,13 @@ eventbriteAPI_v3.prototype.user_venues = function (params, callback) {
  * If you do not include a user_id, we will include one for you :)
  * @see http://developer.eventbrite.com/docs/user-organizers/
  **/
-eventbriteAPI_v3.prototype.user_organizers = function (params, callback) {
-  var user_id = params.user_id || "me";
+eventbriteAPI_v3.prototype.user_organizers = function(params, callback) {
+	var user_id = params.user_id || "me";
 
-  var availableParams = ["page"];
+	var availableParams = ["page"];
 
-  var method = user_id + "/organizers/";
-  this.get('users', method, availableParams, params, callback);
+	var method = user_id + "/organizers/";
+	this.get('users', method, availableParams, params, callback);
 };
 
 


### PR DESCRIPTION
When using the eventbrite API you can specify a changed_since parameter. This is ignored by eventbrite on GET requests when changed_since is used, so you get ALL results back. 

This is obviously an issue on the eventbrite side of the house BUT as it's not important to set the Content-Type header on GET requests (as there is no body), it seems easy enough to fix here.