### PR TITLE
Add subcategories method

### DIFF
--- a/lib/eventbrite/eventbrite_v3.js
+++ b/lib/eventbrite/eventbrite_v3.js
@@ -187,6 +187,20 @@ eventbriteAPI_v3.prototype.categories = function (callback) {
 
 
 /**
+ * This endpoint allows you to retrieve Event subcategory options from across Eventbrite’s directory.
+ *
+ * @see http://developer.eventbrite.com/docs/event-categories/
+ **/
+eventbriteAPI_v3.prototype.subcategories = function (params, callback) {
+  var availableParams = [
+    "page"
+  ];
+
+  this.get('subcategories', null, availableParams, params, callback);
+};
+
+
+/**
  * Retrieves details for a given event_id
  *
  * @see http://developer.eventbrite.com/docs/event-details/


### PR DESCRIPTION
Adds a method to get subcategories. Effectively identical to the category method other than accepting a `page` parameter.