### PR TITLE
Use Content-Type only in POST requests!!

### DIFF
--- a/lib/eventbrite/eventbrite_v3.js
+++ b/lib/eventbrite/eventbrite_v3.js
@@ -41,13 +41,16 @@ module.exports = eventbriteAPI_v3;
  */
 eventbriteAPI_v3.prototype.execute = function (verb, resource, method, availableParams, givenParams, callback) {
   if (!verb) {
-    verb = "GET";
-  }
-  var headers = {
-    "Content-Type": this.contentType,
-    "Authorization": 'Bearer ' + this.token,
-    "User-Agent": this.userAgent
-  };
+        verb = "GET";
+    }
+    var headers = {
+        "Authorization": 'Bearer ' + this.token,
+        "User-Agent": this.userAgent
+    };
+
+    if (verb === "POST") {
+        headers["Content-type"] = this.contentType;
+    }
 
   var uri = this.httpUri + '/' + this.version + '/' + resource + '/';
 


### PR DESCRIPTION
Following @millsy suggestion, I have been struggling with this for 2 days when I realized it could be a node-eventbrite bug.

All requests using GET parameters such as search, will ignore the input parameters if Content-Type is set.

Hi guys. what @millsy is saying is absolutely true!

I was fighting with this issue for 2 days when I started to think that it could be a bug within the node-eventbrite node module.

Figured out after reading here that what @millsy is saying is actually true for ALL REQUESTS!

I was trying to perform a search based on location using the parameters:

location.latitude
location.longitude
location.within

and I was always getting an unfiltered response from eventbrite.

Please accept his pull request. This is a serious issue.

If you guys lost his PR because of merging the deal is really simple:

Here's what I could come up with by reading his post:

First lines of the eventBritAPI_v3.prototype.execute could be changed to this:

if (!verb) { verb = "GET"; }
var headers = { "Authorization": 'Bearer ' + this.token, "User-Agent": this.userAgent };
if (verb === "POST") { headers["Content-type"] = this.contentType; }


As @Ibash requested I have updated the editor to use only two spaces. Please accept the PR because other users will have the same problem soon.