### PR TITLE
Altered event_attendees function to allow attendee_id to be passed to…

### DIFF
--- a/lib/eventbrite/eventbrite_v3.js
+++ b/lib/eventbrite/eventbrite_v3.js
@@ -244,6 +244,11 @@ eventbriteAPI_v3.prototype.event_attendees = function (params, callback) {
     "expand"
   ];
   var method = params.event_id + "/attendees/";
+  
+  if(params.attendee_id){
+    method += params.attendee_id;
+  }
+ 
   this.get('events', method, availableParams, params, callback);
 };
 


### PR DESCRIPTION
As per the API docs, it's possible to return a single attendee rather than all attendees. Initially I added another method to return a single attendee and then settled on this approach, same function with an optional parameter for attendee_id.