### PR TITLE
DRY out conditional logging `ifs`

### DIFF
--- a/lib/eventbrite/eventbrite_v3.js
+++ b/lib/eventbrite/eventbrite_v3.js
@@ -1,6 +1,7 @@
 var http = require('http'),
   request = require('request'),
-  helpers = require('./helpers');
+  helpers = require('./helpers'),
+  logInDebug = ()=>{};
 
 /**
  * eventbrite API wrapper for the API version 3. This object should not be
@@ -23,6 +24,8 @@ function eventbriteAPI_v3(options) {
   this.DEBUG = options.DEBUG || false;
   this.contentType = options.contentType || 'application/json';
   this.userAgent = options.userAgent || 'node-eventbrite/' + this.version;
+  
+  logInDebug = helpers.loggerWhenTrue(this.DEBUG);
 }
 
 module.exports = eventbriteAPI_v3;
@@ -68,12 +71,10 @@ eventbriteAPI_v3.prototype.execute = function (verb, resource, method, available
       finalParams[currentParam] = givenParams[currentParam];
   }
 
-  if (this.DEBUG) {
-    console.log("uri", uri);
-    console.log("verb", verb);
-    console.log("headers", headers);
-    console.log("finalParams", finalParams);
-  }
+  logInDebug("uri", uri);
+  logInDebug("verb", verb);
+  logInDebug("headers", headers);
+  logInDebug("finalParams", finalParams);
 
   // Build our request object
   var requestObject = {
@@ -96,7 +97,7 @@ eventbriteAPI_v3.prototype.execute = function (verb, resource, method, available
   request(requestObject, function (error, response, body) {
     var parsedResponse;
     if (error) {
-      if (this.DEBUG)console.log("error", error);
+      logInDebug("error", error);
       var err = new Error('Unable to connect to the eventbrite API endpoint.');
       err.error_message = error;
       err.code = "REQUEST_ERROR";
@@ -106,11 +107,11 @@ eventbriteAPI_v3.prototype.execute = function (verb, resource, method, available
       try {
         parsedResponse = JSON.parse(body);
         if (parsedResponse.error){
-          if (this.DEBUG)console.log("error", parsedResponse.error, parsedResponse.error_description);
+          logInDebug("error", parsedResponse.error, parsedResponse.error_description);
           return callback(helpers.createEventbriteError(parsedResponse));
         }
       } catch (error) {
-        if (this.DEBUG)console.log("error", error);
+        logInDebug("error", error);
         return callback(new Error('Error parsing JSON answer from eventbrite API.'));
       }
 

--- a/lib/eventbrite/eventbrite_v3.js
+++ b/lib/eventbrite/eventbrite_v3.js
@@ -1,7 +1,7 @@
 var http = require('http'),
   request = require('request'),
   helpers = require('./helpers'),
-  logInDebug = ()=>{};
+  logIfDebug = ()=>{};
 
 /**
  * eventbrite API wrapper for the API version 3. This object should not be
@@ -25,7 +25,7 @@ function eventbriteAPI_v3(options) {
   this.contentType = options.contentType || 'application/json';
   this.userAgent = options.userAgent || 'node-eventbrite/' + this.version;
   
-  logInDebug = helpers.loggerWhenTrue(this.DEBUG);
+  logIfDebug = helpers.loggerWhenTrue(this.DEBUG);
 }
 
 module.exports = eventbriteAPI_v3;
@@ -71,10 +71,10 @@ eventbriteAPI_v3.prototype.execute = function (verb, resource, method, available
       finalParams[currentParam] = givenParams[currentParam];
   }
 
-  logInDebug("uri", uri);
-  logInDebug("verb", verb);
-  logInDebug("headers", headers);
-  logInDebug("finalParams", finalParams);
+  logIfDebug("uri", uri);
+  logIfDebug("verb", verb);
+  logIfDebug("headers", headers);
+  logIfDebug("finalParams", finalParams);
 
   // Build our request object
   var requestObject = {
@@ -97,7 +97,7 @@ eventbriteAPI_v3.prototype.execute = function (verb, resource, method, available
   request(requestObject, function (error, response, body) {
     var parsedResponse;
     if (error) {
-      logInDebug("error", error);
+      logIfDebug("error", error);
       var err = new Error('Unable to connect to the eventbrite API endpoint.');
       err.error_message = error;
       err.code = "REQUEST_ERROR";
@@ -107,11 +107,11 @@ eventbriteAPI_v3.prototype.execute = function (verb, resource, method, available
       try {
         parsedResponse = JSON.parse(body);
         if (parsedResponse.error){
-          logInDebug("error", parsedResponse.error, parsedResponse.error_description);
+          logIfDebug("error", parsedResponse.error, parsedResponse.error_description);
           return callback(helpers.createEventbriteError(parsedResponse));
         }
       } catch (error) {
-        logInDebug("error", error);
+        logIfDebug("error", error);
         return callback(new Error('Error parsing JSON answer from eventbrite API.'));
       }
 

--- a/lib/eventbrite/helpers.js
+++ b/lib/eventbrite/helpers.js
@@ -92,9 +92,9 @@ exports.createEventbriteError = function (errorResponse) {
 
   return error;
 };
-/**
- * @param statements Arguments to be passed through into logger  
- * @param isDebug Boolean switch for returned logging function
+
+/** 
+ * @param isTrue Boolean switch for returned logging function
  * @returns Guarded alias of console.log
  */
 exports.loggerWhenTrue = (isTrue) => (...statements) => isTrue ? console.log.apply(console, statements) : void 0;

--- a/lib/eventbrite/helpers.js
+++ b/lib/eventbrite/helpers.js
@@ -92,3 +92,9 @@ exports.createEventbriteError = function (errorResponse) {
 
   return error;
 };
+/**
+ * @param statements Arguments to be passed through into logger  
+ * @param isDebug Boolean switch for returned logging function
+ * @returns Guarded alias of console.log
+ */
+exports.loggerWhenDebug = (isDebug) => (...statements) => isDebug ? console.log.apply(console, statements) : void 0;

--- a/lib/eventbrite/helpers.js
+++ b/lib/eventbrite/helpers.js
@@ -97,4 +97,4 @@ exports.createEventbriteError = function (errorResponse) {
  * @param isDebug Boolean switch for returned logging function
  * @returns Guarded alias of console.log
  */
-exports.loggerWhenDebug = (isDebug) => (...statements) => isDebug ? console.log.apply(console, statements) : void 0;
+exports.loggerWhenTrue = (isTrue) => (...statements) => isDebug ? console.log.apply(console, statements) : void 0;

--- a/lib/eventbrite/helpers.js
+++ b/lib/eventbrite/helpers.js
@@ -97,4 +97,4 @@ exports.createEventbriteError = function (errorResponse) {
  * @param isDebug Boolean switch for returned logging function
  * @returns Guarded alias of console.log
  */
-exports.loggerWhenTrue = (isTrue) => (...statements) => isDebug ? console.log.apply(console, statements) : void 0;
+exports.loggerWhenTrue = (isTrue) => (...statements) => isTrue ? console.log.apply(console, statements) : void 0;


### PR DESCRIPTION
1.  create new helper that returns a conditional console.log
2. rename that helper
3. refactor blocks like this: `if (this.DEBUG) console.log('foo')` -> `logInDebug('foo')`
4. Will change logger alias to logIf instead of logIn, which could be confusing in an authenticated context  